### PR TITLE
adding test to properly identify GhostBSD source media

### DIFF
--- a/src-sh/pcbsd-utils/pc-sysinstall/backend/functions-extractimage.sh
+++ b/src-sh/pcbsd-utils/pc-sysinstall/backend/functions-extractimage.sh
@@ -521,6 +521,10 @@ init_extraction()
           INSFILE="${INSDIR}"
           ;;
       esac
+    elif [ "$INSTALLTYPE" = "GhostBSD" ]
+    then
+	# this file identify a GhostBSD DVD/USB image
+	INSFILE="/etc/rc.conf.ghostbsd"
     else
       case $PACKAGETYPE in
         uzip) INSFILE="${UZIP_FILE}" ;;


### PR DESCRIPTION
tested both DVD and USB, no regression introduced, please test and see if it solve your issue.